### PR TITLE
mantaray pkg for persisted compacted tries

### DIFF
--- a/mantaray/marshal.go
+++ b/mantaray/marshal.go
@@ -1,0 +1,140 @@
+package mantaray
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	preambleSize = 64
+	forkSize     = 64
+)
+
+var (
+	// ErrTooShort too short input
+	ErrTooShort = errors.New("serialised input too short")
+	// ErrInvalid input to seralise invalid
+	ErrInvalid = errors.New("input invalid")
+	// ErrForkIvalid shows embedded node on a fork has no reference
+	ErrForkIvalid = errors.New("fork node without reference")
+)
+
+// MarshalBinary serialises the node
+func (n *Node) MarshalBinary() (bytes []byte, err error) {
+	if n.forks == nil {
+		return nil, ErrInvalid
+	}
+	var index = &bitsForBytes{}
+	for k := range n.forks {
+		index.set(k)
+	}
+	bytes = make([]byte, 32)
+	copy(bytes, n.entry)
+	bytes = append(bytes, index.bytes()...)
+	err = index.iter(func(b byte) error {
+		f := n.forks[b]
+		ref, err := f.bytes()
+		if err != nil {
+			return fmt.Errorf("%w on byte '%x'", err, []byte{b})
+		}
+		bytes = append(bytes, ref...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+// bitsForBytes is a set of bytes represented as a 256-length bitvector
+type bitsForBytes struct {
+	bits [32]byte
+}
+
+func (bb *bitsForBytes) bytes() (b []byte) {
+	b = append(b, bb.bits[:]...)
+	return b
+}
+
+func (bb *bitsForBytes) fromBytes(b []byte) {
+	copy(bb.bits[:], b)
+}
+
+func (bb *bitsForBytes) set(b byte) {
+	bb.bits[uint8(b)/8] |= 1 << (uint8(b) % 8)
+}
+
+func (bb *bitsForBytes) get(b byte) bool {
+	return bb.getUint8(uint8(b))
+}
+
+func (bb *bitsForBytes) getUint8(i uint8) bool {
+	return (bb.bits[i/8]>>(i%8))&1 > 0
+}
+
+func (bb *bitsForBytes) iter(f func(byte) error) error {
+	for i := uint8(0); ; i++ {
+		if bb.getUint8(i) {
+			if err := f(byte(i)); err != nil {
+				return err
+			}
+		}
+		if i == 255 {
+			return nil
+		}
+	}
+}
+
+// UnmarshalBinary deserialises a node
+func (n *Node) UnmarshalBinary(bytes []byte) error {
+	if len(bytes) < preambleSize {
+		return ErrTooShort
+	}
+	n.entry = append([]byte{}, bytes[0:32]...)
+	n.forks = make(map[byte]*fork)
+	offset := preambleSize
+	bb := &bitsForBytes{}
+	bb.fromBytes(bytes[32:])
+	bb.iter(func(b byte) error {
+		f := &fork{}
+		f.fromBytes(bytes[offset : offset+forkSize])
+		n.forks[b] = f
+		offset += forkSize
+		return nil
+	})
+	return nil
+}
+
+func (f *fork) fromBytes(b []byte) {
+	f.prefix = bytesToPrefix(b[:32])
+	f.Node = NewNodeRef(b[32:64])
+}
+
+func (f *fork) bytes() (b []byte, err error) {
+	b = append(b, prefixToBytes(f.prefix)...)
+	r := refBytes(f)
+	b = append(b, r...)
+	return b, nil
+}
+
+var refBytes = nodeRefBytes
+
+func nodeRefBytes(f *fork) []byte {
+	return f.Node.ref
+}
+
+func prefixToBytes(prefix []byte) (bytes []byte) {
+	bytes = append(bytes, prefix...)
+	for i := len(prefix); i < 32; i++ {
+		bytes = append(bytes, '/')
+	}
+	return bytes
+}
+func bytesToPrefix(bytes []byte) (prefix []byte) {
+	for _, b := range bytes {
+		if b != '/' {
+			prefix = append(prefix, b)
+		}
+	}
+	return prefix
+}

--- a/mantaray/marshal_test.go
+++ b/mantaray/marshal_test.go
@@ -1,0 +1,80 @@
+package mantaray
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+const testMarshalOutput = "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000061616161612f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f000000000000000000000000000000000000000000000000000000000000000063632f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f0000000000000000000000000000000000000000000000000000000000000001642f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f000000000000000000000000000000000000000000000000000000000000000265652f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f0000000000000000000000000000000000000000000000000000000000000003"
+
+var testPrefixes = [][]byte{
+	[]byte("aaaaa"),
+	[]byte("cc"),
+	[]byte("d"),
+	[]byte("ee"),
+}
+
+func TestUnmarshal(t *testing.T) {
+	input, _ := hex.DecodeString(testMarshalOutput)
+	n := &Node{}
+	err := n.UnmarshalBinary(input)
+	if err != nil {
+		t.Fatalf("expected no error marshaling, got %v", err)
+	}
+	exp := testMarshalOutput[:64]
+	if hex.EncodeToString(n.entry) != exp {
+		t.Fatalf("expected %x, got %x", exp, n.entry)
+	}
+	if len(testPrefixes) != len(n.forks) {
+		t.Fatalf("expected %d forks, got %d", len(testPrefixes), len(n.forks))
+	}
+	for _, prefix := range testPrefixes {
+		f := n.forks[prefix[0]]
+		if f == nil {
+			t.Fatalf("expected to have  fork on byte %x", prefix[:1])
+		}
+		if !bytes.Equal(f.prefix, prefix) {
+			t.Fatalf("expected prefix for byte %x to match %s, got %s", prefix[:1], prefix, f.prefix)
+		}
+	}
+}
+func TestMarshal(t *testing.T) {
+	n := New()
+	defer func(r func(*fork) []byte) { refBytes = r }(refBytes)
+	i := uint8(0)
+	refBytes = func(*fork) []byte {
+		b := make([]byte, 32)
+		b[31] = byte(i)
+		i++
+		return b
+	}
+	for i := 0; i < len(testPrefixes); i++ {
+		c := testPrefixes[i]
+		n.Add(c, c, nil)
+	}
+	b, err := n.MarshalBinary()
+	if err != nil {
+		t.Fatalf("expected no error marshaling, got %v", err)
+	}
+	exp, _ := hex.DecodeString(testMarshalOutput)
+	if !bytes.Equal(b, exp) {
+		t.Fatalf("expected marshalled output to match %x, got %x", exp, b)
+	}
+	// n = &Node{}
+	// err = n.UnmarshalBinary(b)
+	// if err != nil {
+	// 	t.Fatalf("expected no error unmarshaling, got %v", err)
+	// }
+
+	// for j := 0; j < len(testCases); j++ {
+	// 	d := testCases[j]
+	// 	m, err := n.Lookup(d, nil)
+	// 	if err != nil {
+	// 		t.Fatalf("expected no error, got %v", err)
+	// 	}
+	// 	if !bytes.Equal(m, d) {
+	// 		t.Fatalf("expected value %x, got %x", d, m)
+	// 	}
+	// }
+}

--- a/mantaray/node.go
+++ b/mantaray/node.go
@@ -1,0 +1,100 @@
+package mantaray
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error used when lookup path does not match
+var (
+	ErrNotFound = errors.New("not found")
+)
+
+// Node represents a mantaray Node
+type Node struct {
+	ref   []byte // reference to uninstantiated Node persisted serialised
+	entry []byte
+	forks map[byte]*fork
+}
+
+type fork struct {
+	prefix []byte // the non-branching part of the subpath
+	*Node         // in memory structure that represents the Node
+}
+
+// NewNodeRef is the exported Node constructor used to represent manifests by reference
+func NewNodeRef(ref []byte) *Node {
+	return &Node{ref: ref}
+}
+
+// New is the constructor for in-memory Node structure
+func New() *Node {
+	return &Node{forks: make(map[byte]*fork)}
+}
+
+func notFound(path []byte) error {
+	return fmt.Errorf("entry on '%s' ('%x'): %w", path, path, ErrNotFound)
+}
+
+// Lookup finds the entry for a path or returns error if not found
+func (n *Node) Lookup(path []byte, l Loader) ([]byte, error) {
+	if n.forks == nil {
+		if err := n.load(l); err != nil {
+			return nil, err
+		}
+	}
+	if len(path) == 0 {
+		return n.entry, nil
+	}
+	f := n.forks[path[0]]
+	if f == nil {
+		return nil, notFound(path)
+	}
+	c := common(f.prefix, path)
+	if len(c) == len(f.prefix) {
+		return f.Node.Lookup(path[len(c):], l)
+	}
+	return nil, notFound(path)
+}
+
+// Add adds an entry to the path
+func (n *Node) Add(path []byte, entry []byte, ls LoadSaver) error {
+	if len(path) == 0 {
+		n.entry = entry
+		n.ref = nil
+		return nil
+	}
+	if n.forks == nil {
+		if err := n.load(ls); err != nil {
+			return err
+		}
+		n.ref = nil
+	}
+	f := n.forks[path[0]]
+	if f == nil {
+		nn := New()
+		nn.entry = entry
+		n.forks[path[0]] = &fork{path, nn}
+		return nil
+	}
+	c := common(f.prefix, path)
+	rest := f.prefix[len(c):]
+	nn := f.Node
+	if len(rest) > 0 {
+		nn = New()
+		nn.forks[rest[0]] = &fork{rest, f.Node}
+	}
+	err := nn.Add(path[len(c):], entry, ls)
+	if err != nil {
+		return err
+	}
+	n.forks[path[0]] = &fork{c, nn}
+	return nil
+}
+
+func common(a, b []byte) (c []byte) {
+	for i := 0; i < len(a) && i < len(b) && a[i] == b[i]; i++ {
+		c = append(c, a[i])
+	}
+	return c
+}

--- a/mantaray/node_test.go
+++ b/mantaray/node_test.go
@@ -1,0 +1,46 @@
+package mantaray
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNilPath(t *testing.T) {
+	n := New()
+	_, err := n.Lookup(nil, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestAddAndLookup(t *testing.T) {
+	n := New()
+	testCases := [][]byte{
+		[]byte("aaaaaa"),
+		[]byte("aaaaab"),
+		[]byte("abbbb"),
+		[]byte("abbba"),
+		[]byte("bbbbba"),
+		[]byte("bbbaaa"),
+		[]byte("bbbaab"),
+		[]byte("aa"),
+		[]byte("b"),
+	}
+	for i := 0; i < len(testCases); i++ {
+		c := testCases[i]
+		err := n.Add(c, c, nil)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		for j := 0; j < i; j++ {
+			d := testCases[j]
+			m, err := n.Lookup(d, nil)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if !bytes.Equal(m, d) {
+				t.Fatalf("expected value %x, got %x", d, m)
+			}
+		}
+	}
+}

--- a/mantaray/persist.go
+++ b/mantaray/persist.go
@@ -1,0 +1,99 @@
+package mantaray
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	// ErrNoSaver  saver interface not given
+	ErrNoSaver = errors.New("Node is not persisted but no saver")
+	// ErrNoLoader saver interface not given
+	ErrNoLoader = errors.New("Node is reference but no loader")
+)
+
+// Loader  defines a generic interface to retrieve nodes
+// from a persistent storage
+// for read only  operations only
+type Loader interface {
+	Load([]byte) ([]byte, error)
+}
+
+// Saver  defines a generic interface to persist  nodes
+// for write operations
+type Saver interface {
+	Save([]byte) ([]byte, error)
+}
+
+// LoadSaver is a composite interface of Loader and Saver
+// it is meant to be implemented as  thin wrappers around persistent storage like Swarm
+type LoadSaver interface {
+	Loader
+	Save([]byte) ([]byte, error)
+}
+
+func (n *Node) load(l Loader) error {
+	if n == nil || n.ref == nil {
+		return nil
+	}
+	if l == nil {
+		return ErrNoLoader
+	}
+	b, err := l.Load(n.ref)
+	if err != nil {
+		return err
+	}
+	if err := n.UnmarshalBinary(b); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Save persists a trie recursively  traversing the nodes
+func (n *Node) Save(s Saver) error {
+	if s == nil {
+		return ErrNoSaver
+	}
+	errc := make(chan error, 1)
+	closed := make(chan struct{})
+	n.save(s, errc, closed)
+	select {
+	case err := <-errc:
+		return err
+	default:
+	}
+	return nil
+
+}
+
+func (n *Node) save(s Saver, errc chan error, closed chan struct{}) {
+	if n != nil && n.ref != nil {
+		return
+	}
+	var wg sync.WaitGroup
+	for _, f := range n.forks {
+		wg.Add(1)
+		go func(f *fork) {
+			defer wg.Done()
+			f.Node.save(s, errc, closed)
+		}(f)
+	}
+	wg.Wait()
+	select {
+	case <-closed:
+		return
+	default:
+	}
+	bytes, err := n.MarshalBinary()
+	if err == nil {
+		n.ref, err = s.Save(bytes)
+	}
+	if err != nil {
+		select {
+		case errc <- err:
+			close(closed)
+		default:
+		}
+	}
+	n.forks = nil
+}

--- a/mantaray/persist_test.go
+++ b/mantaray/persist_test.go
@@ -1,0 +1,93 @@
+package mantaray_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"sync"
+	"testing"
+
+	"github.com/ethersphere/manifests/mantaray"
+)
+
+func TestPersistIdempotence(t *testing.T) {
+	n := mantaray.New()
+	paths := [][]byte{
+		[]byte("aa"),
+		// []byte("b"),
+		// []byte("aaaaaa"),
+		// []byte("aaaaab"),
+		// []byte("abbbb"),
+		// []byte("abbba"),
+		// []byte("bbbbba"),
+		// []byte("bbbaaa"),
+		// []byte("bbbaab"),
+	}
+	var ls mantaray.LoadSaver = newMockLoadSaver()
+	for i := 0; i < len(paths); i++ {
+		c := paths[i]
+		err := n.Save(ls)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		var v [32]byte
+		copy(v[:], c)
+		err = n.Add(c, v[:], ls)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	}
+	err := n.Save(ls)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	for i := 0; i < len(paths); i++ {
+		c := paths[i]
+		m, err := n.Lookup(c, ls)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		var v [32]byte
+		copy(v[:], c)
+		if !bytes.Equal(m, v[:]) {
+			t.Fatalf("expected value %x, got %x", v[:], m)
+		}
+	}
+}
+
+type addr [32]byte
+type mockLoadSaver struct {
+	mtx   sync.Mutex
+	store map[addr][]byte
+}
+
+func newMockLoadSaver() *mockLoadSaver {
+	return &mockLoadSaver{
+		store: make(map[addr][]byte),
+	}
+}
+
+func (m *mockLoadSaver) Save(b []byte) ([]byte, error) {
+	var a addr
+	hasher := sha256.New()
+	_, err := hasher.Write(b)
+	if err != nil {
+		return nil, err
+	}
+	copy(a[:], hasher.Sum(nil))
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.store[a] = b
+	return a[:], nil
+}
+
+func (m *mockLoadSaver) Load(ab []byte) ([]byte, error) {
+	var a addr
+	copy(a[:], ab)
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	b, ok := m.store[a]
+	if !ok {
+		return nil, mantaray.ErrNotFound
+	}
+	return b, nil
+}


### PR DESCRIPTION
first iteration of new persisted compacted trie 

- add,  lookup
- persistance via LoadSaver interface
- compact serialisation of sparse byte map

caveats/TODOs:

- allow >32 byte prefixes
- dir/fork distinction, dir listing 
- allow encrypted references
- add iterator
- add concurrent merge 
- add remove
- allow tiling - compact multiple node into a chunk