### PR TITLE
Add HasPrefix function to manifest implementations

### DIFF
--- a/mantaray/node.go
+++ b/mantaray/node.go
@@ -289,3 +289,27 @@ func common(a, b []byte) (c []byte) {
 	}
 	return c
 }
+
+// HasPrefix tests whether the node contains prefix path.
+func (n *Node) HasPrefix(path []byte, l Loader) (bool, error) {
+	if n.forks == nil {
+		if err := n.load(l); err != nil {
+			return false, err
+		}
+	}
+	if len(path) == 0 {
+		return true, nil
+	}
+	f := n.forks[path[0]]
+	if f == nil {
+		return false, nil
+	}
+	c := common(f.prefix, path)
+	if len(c) == len(f.prefix) {
+		return f.Node.HasPrefix(path[len(c):], l)
+	}
+	if bytes.HasPrefix(f.prefix, path) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/mantaray/node_test.go
+++ b/mantaray/node_test.go
@@ -156,3 +156,74 @@ func TestRemove(t *testing.T) {
 		})
 	}
 }
+
+func TestHasPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		toAdd       [][]byte
+		testPrefix  [][]byte
+		shouldExist []bool
+	}{
+		{
+			name: "simple",
+			toAdd: [][]byte{
+				[]byte("index.html"),
+				[]byte("img/1.png"),
+				[]byte("img/2.png"),
+				[]byte("robots.txt"),
+			},
+			testPrefix: [][]byte{
+				[]byte("img/"),
+				[]byte("images/"),
+			},
+			shouldExist: []bool{
+				true,
+				false,
+			},
+		},
+		{
+			name: "nested-single",
+			toAdd: [][]byte{
+				[]byte("some-path/file.ext"),
+			},
+			testPrefix: [][]byte{
+				[]byte("some-path/"),
+				[]byte("some-path/file"),
+				[]byte("some-other-path/"),
+			},
+			shouldExist: []bool{
+				true,
+				true,
+				false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := New()
+
+			for i := 0; i < len(tc.toAdd); i++ {
+				c := tc.toAdd[i]
+				e := append(make([]byte, 32-len(c)), c...)
+				err := n.Add(c, e, nil, nil)
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			}
+
+			for i := 0; i < len(tc.testPrefix); i++ {
+				testPrefix := tc.testPrefix[i]
+				shouldExist := tc.shouldExist[i]
+
+				exists, err := n.HasPrefix(testPrefix, nil)
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+
+				if shouldExist != exists {
+					t.Errorf("expected prefix path %s to be %t, was %t", testPrefix, shouldExist, exists)
+				}
+			}
+
+		})
+	}
+}

--- a/simple/manifest.go
+++ b/simple/manifest.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -26,6 +27,8 @@ type Manifest interface {
 	Remove(string) error
 	// Lookup returns a manifest node entry if one is found in the specified path.
 	Lookup(string) (Entry, error)
+	// HasPrefix tests whether the specified prefix path exists.
+	HasPrefix(string) bool
 	// Length returns an implementation-specific count of elements in the manifest.
 	// For Manifest, this means the number of all the existing entries.
 	Length() int
@@ -90,6 +93,19 @@ func (m *manifest) Lookup(path string) (Entry, error) {
 
 	// return a copy to prevent external modification
 	return newEntry(entry.Reference(), entry.Metadata()), nil
+}
+
+func (m *manifest) HasPrefix(path string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for k := range m.Entries {
+		if strings.HasPrefix(k, path) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m *manifest) Length() int {

--- a/simple/manifest_test.go
+++ b/simple/manifest_test.go
@@ -220,3 +220,69 @@ func TestMarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestHasPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		toAdd       []string
+		testPrefix  []string
+		shouldExist []bool
+	}{
+		{
+			name: "simple",
+			toAdd: []string{
+				"index.html",
+				"img/1.png",
+				"img/2.png",
+				"robots.txt",
+			},
+			testPrefix: []string{
+				"img/",
+				"images/",
+			},
+			shouldExist: []bool{
+				true,
+				false,
+			},
+		},
+		{
+			name: "nested-single",
+			toAdd: []string{
+				"some-path/file.ext",
+			},
+			testPrefix: []string{
+				"some-path/",
+				"some-path/file",
+				"some-other-path/",
+			},
+			shouldExist: []bool{
+				true,
+				true,
+				false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := simple.NewManifest()
+
+			for _, e := range tc.toAdd {
+				err := m.Add(e, "", nil)
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			}
+
+			for i := 0; i < len(tc.testPrefix); i++ {
+				testPrefix := tc.testPrefix[i]
+				shouldExist := tc.shouldExist[i]
+
+				exists := m.HasPrefix(testPrefix)
+
+				if shouldExist != exists {
+					t.Errorf("expected prefix path %s to be %t, was %t", testPrefix, shouldExist, exists)
+				}
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
**NOTE**: builds on open PR #8 

Added `HasPrefix` function to manifest implementations, that tests whether among the entries specified path exists.
This was done in order to be used to check if some directory (path ending with slash character) exists.

At first I had more specific function, but figured that was just special case, and this might come in handy for something else in the future.