### PR TITLE
Check if split node should be value type

### DIFF
--- a/mantaray/node.go
+++ b/mantaray/node.go
@@ -239,6 +239,10 @@ func (n *Node) Add(path []byte, entry []byte, metadata map[string]string, ls Loa
 		f.Node.updateIsWithPathSeparator(rest)
 		nn.forks[rest[0]] = &fork{rest, f.Node}
 		nn.makeEdge()
+		// if common path is full path new node is value type
+		if len(path) == len(c) {
+			nn.makeValue()
+		}
 	}
 	// NOTE: special case on edge split
 	nn.updateIsWithPathSeparator(path)


### PR DESCRIPTION
Fixes issue found for SPA website, where a file path is added which is superset of following file path, in which case previously that new (shorter path) was not marked as being "value" type (even though it should be).

Since this value-type check is used to validate if the file exists, this change should fix issues there.

Additional tests were added to test this case.