### PR TITLE
Update to walker functions

### DIFF
--- a/mantaray/marshal.go
+++ b/mantaray/marshal.go
@@ -87,6 +87,14 @@ var obfuscationKeyFn = func(p []byte) (n int, err error) {
 	return rand.Read(p)
 }
 
+// SetObfuscationKeyFn allows configuring custom function for generating
+// obfuscation key.
+//
+// NOTE: This should only be used in tests.
+func SetObfuscationKeyFn(fn func([]byte) (int, error)) {
+	obfuscationKeyFn = fn
+}
+
 // MarshalBinary serialises the node
 func (n *Node) MarshalBinary() (bytes []byte, err error) {
 	if n.forks == nil {

--- a/mantaray/walker.go
+++ b/mantaray/walker.go
@@ -20,22 +20,18 @@ func walkNode(path []byte, l Loader, n *Node, walkFn WalkNodeFunc) error {
 		}
 	}
 
-	if n.IsValueType() {
-		err := walkNodeFnCopyBytes(path, n, nil, walkFn)
-		if err != nil {
-			return err
-		}
+	err := walkNodeFnCopyBytes(path, n, nil, walkFn)
+	if err != nil {
+		return err
 	}
 
-	if n.IsEdgeType() {
-		for _, v := range n.forks {
-			nextPath := append(path[:0:0], path...)
-			nextPath = append(nextPath, v.prefix...)
+	for _, v := range n.forks {
+		nextPath := append(path[:0:0], path...)
+		nextPath = append(nextPath, v.prefix...)
 
-			err := walkNode(nextPath, l, v.Node, walkFn)
-			if err != nil {
-				return err
-			}
+		err := walkNode(nextPath, l, v.Node, walkFn)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/mantaray/walker_test.go
+++ b/mantaray/walker_test.go
@@ -12,13 +12,23 @@ import (
 
 func TestWalkNode(t *testing.T) {
 	for _, tc := range []struct {
-		name  string
-		toAdd [][]byte
+		name     string
+		toAdd    [][]byte
+		expected [][]byte
 	}{
 		{
 			name: "simple",
 			toAdd: [][]byte{
 				[]byte("index.html"),
+				[]byte("img/1.png"),
+				[]byte("img/2.png"),
+				[]byte("robots.txt"),
+			},
+			expected: [][]byte{
+				[]byte(""),
+				[]byte("i"),
+				[]byte("index.html"),
+				[]byte("img/"),
 				[]byte("img/1.png"),
 				[]byte("img/2.png"),
 				[]byte("robots.txt"),
@@ -44,8 +54,8 @@ func TestWalkNode(t *testing.T) {
 
 				pathFound := false
 
-				for i := 0; i < len(tc.toAdd); i++ {
-					c := tc.toAdd[i]
+				for i := 0; i < len(tc.expected); i++ {
+					c := tc.expected[i]
 					if bytes.Equal(path, c) {
 						pathFound = true
 						break
@@ -64,8 +74,8 @@ func TestWalkNode(t *testing.T) {
 				t.Fatalf("no error expected, found: %s", err)
 			}
 
-			if len(tc.toAdd) != walkedCount {
-				t.Errorf("expected %d nodes, got %d", len(tc.toAdd), walkedCount)
+			if len(tc.expected) != walkedCount {
+				t.Errorf("expected %d nodes, got %d", len(tc.expected), walkedCount)
 			}
 
 		})

--- a/simple/manifest.go
+++ b/simple/manifest.go
@@ -33,6 +33,10 @@ type Manifest interface {
 	// For Manifest, this means the number of all the existing entries.
 	Length() int
 
+	// WalkEntry walks all entries, calling walkFn for each entry in the map.
+	// All errors that arise visiting entires are filtered by walkFn.
+	WalkEntry(string, WalkEntryFunc) error
+
 	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
 }

--- a/simple/walker.go
+++ b/simple/walker.go
@@ -1,0 +1,24 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package simple
+
+// WalkEntryFunc is the type of the function called for each entry visited
+// by WalkEntry.
+type WalkEntryFunc func(path string, entry Entry, err error) error
+
+func (m *manifest) WalkEntry(root string, walkFn WalkEntryFunc) (err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for k, v := range m.Entries {
+		entry := newEntry(v.Ref, v.Meta)
+		err = walkFn(k, entry, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/simple/walker_test.go
+++ b/simple/walker_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package simple_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethersphere/manifest/simple"
+)
+
+func TestWalkEntry(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := simple.NewManifest()
+
+			// add entries
+			for _, e := range tc.entries {
+				err := m.Add(e.path, e.reference, e.metadata)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			manifestLen := m.Length()
+
+			if len(tc.entries) != manifestLen {
+				t.Fatalf("expected %d entries, found %d", len(tc.entries), manifestLen)
+			}
+
+			walkedCount := 0
+
+			walker := func(path string, entry simple.Entry, err error) error {
+				walkedCount++
+
+				pathFound := false
+
+				for i := 0; i < len(tc.entries); i++ {
+					p := tc.entries[i].path
+					if path == p {
+						pathFound = true
+						break
+					}
+				}
+
+				if !pathFound {
+					return fmt.Errorf("walkFn returned unknown path: %s", path)
+				}
+
+				return nil
+			}
+			// Expect no errors.
+			err := m.WalkEntry("", walker)
+			if err != nil {
+				t.Fatalf("no error expected, found: %s", err)
+			}
+
+			if len(tc.entries) != walkedCount {
+				t.Errorf("expected %d nodes, got %d", len(tc.entries), walkedCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Few changes required for iteration:
* includes "walker" function for `simple` manifest implementation.
* updates `mantaray` implementation to actually process all nodes of the trie

One additional side-change is addition of function (in the `mantaray` implementation) that should be used for generation of obfuscation key.
While working for some external requirements, it became increasingly difficult to test the library, hence the addition. If there are some other ideas for solving this, I would appreciate.