### PR TITLE
Copy obfuscation key to child trie nodes

### DIFF
--- a/mantaray/node.go
+++ b/mantaray/node.go
@@ -16,11 +16,11 @@ const (
 )
 
 var (
-	DefaultObfuscationKey []byte
+	ZeroObfuscationKey []byte
 )
 
 func init() {
-	DefaultObfuscationKey = make([]byte, 32)
+	ZeroObfuscationKey = make([]byte, 32)
 }
 
 // Error used when lookup path does not match

--- a/mantaray/node.go
+++ b/mantaray/node.go
@@ -15,6 +15,14 @@ const (
 	PathSeparator = '/' // path separator
 )
 
+var (
+	DefaultObfuscationKey []byte
+)
+
+func init() {
+	DefaultObfuscationKey = make([]byte, 32)
+}
+
 // Error used when lookup path does not match
 var (
 	ErrNotFound         = errors.New("not found")

--- a/mantaray/node.go
+++ b/mantaray/node.go
@@ -215,6 +215,9 @@ func (n *Node) Add(ctx context.Context, path []byte, entry []byte, metadata map[
 	f := n.forks[path[0]]
 	if f == nil {
 		nn := New()
+		if len(n.obfuscationKey) > 0 {
+			nn.SetObfuscationKey(n.obfuscationKey)
+		}
 		nn.refBytesSize = n.refBytesSize
 		// check for prefix size limit
 		if len(path) > nodePrefixMaxSize {
@@ -246,6 +249,9 @@ func (n *Node) Add(ctx context.Context, path []byte, entry []byte, metadata map[
 	if len(rest) > 0 {
 		// move current common prefix node
 		nn = New()
+		if len(n.obfuscationKey) > 0 {
+			nn.SetObfuscationKey(n.obfuscationKey)
+		}
 		nn.refBytesSize = n.refBytesSize
 		f.Node.updateIsWithPathSeparator(rest)
 		nn.forks[rest[0]] = &fork{rest, f.Node}


### PR DESCRIPTION
relates to: [ethersphere/bee#1006](https://github.com/ethersphere/bee/issues/1006)

Copy obfuscation key to child trie nodes if one is configured.

In the case when obfuscation key is not configured, global function for generating obfuscation key will be used, which in this case will generate some random key.

Another thing that was added is `ZeroObfuscationKey` constant, which is empty byte slice. Having this seemed better solution than adding another property to `Node` struct, that would just notify that manifest is encrypted.